### PR TITLE
fix(desktop): accept native voice IDs with spaces/backslashes (Windows SAPI)

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -177,8 +177,15 @@ impl SpeakRequest {
     }
 }
 
-/// Shared voice ID validation: only alphanumeric, dots, underscores, and hyphens allowed.
-/// Matches the validation in iOS (CharacterSet) and Android (VOICE_ID_PATTERN).
+/// Shared voice ID validation. The id is matched by exact equality against the
+/// engine's own voices in `speak()` / `preview_voice()`, so this only guards
+/// against pathological input (too long, or containing control characters).
+///
+/// A stricter charset filter cannot be used here: native Windows SAPI voice ids
+/// returned by `get_voices()` are registry tokens that contain spaces and
+/// backslashes (e.g. `HKEY_LOCAL_MACHINE\...\Tokens\TTS_MS_EN-US_ZIRA_11.0`), so
+/// restricting to `[alphanumeric . _ -]` rejected every selectable voice on
+/// Windows.
 fn validate_voice_id(voice_id: &str) -> Result<(), ValidationError> {
     if voice_id.len() > MAX_VOICE_ID_LENGTH {
         return Err(ValidationError::VoiceIdTooLong {
@@ -186,10 +193,7 @@ fn validate_voice_id(voice_id: &str) -> Result<(), ValidationError> {
             max: MAX_VOICE_ID_LENGTH,
         });
     }
-    if !voice_id
-        .chars()
-        .all(|c| c.is_alphanumeric() || c == '.' || c == '_' || c == '-')
-    {
+    if voice_id.chars().any(|c| c.is_control()) {
         return Err(ValidationError::InvalidVoiceId);
     }
     Ok(())


### PR DESCRIPTION
## Problem

On Windows, `get_voices()` returns voice ids straight from the engine (`v.id()`). For SAPI voices these are registry tokens that contain **spaces and backslashes**, e.g. `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\TTS_MS_EN-US_ZIRA_11.0`.

`speak()` and `preview_voice()` then call `validate_voice_id`, which only allows `[alphanumeric . _ -]`. As a result **every** non-default voice returned by `get_voices()` is rejected with `ValidationError::InvalidVoiceId` ("Invalid voice ID format - only alphanumeric, dots, underscores, and hyphens allowed"), so voice selection is impossible on Windows.

### Repro
On Windows: `getVoices()` -> take any returned voice id -> `speak({ text, voiceId })` (or `previewVoice({ voiceId })`) -> the error above. Only the engine default voice (no `voiceId`) works.

## Fix

Relax `validate_voice_id` to reject only control characters (keeping the existing length bound). The id is matched by exact equality against the engine's own voice list in `speak()` / `preview_voice()`, so the strict charset check added no real safety against bad input.

## Notes

- Only the shared Rust (desktop) validator is changed; iOS/Android keep their own validators, and the macOS/Linux id formats already passed.
- No change to the public API or to `get_voices()` output.