### PR TITLE
Solve the issue where TTS does not work in Xiaomi HyperOS and OPPO ColorOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,17 @@ sudo pacman -S speech-dispatcher
 2. Install "Google Text-to-Speech" from Play Store if missing
 3. Download language data for your desired languages
 
+### Xiaomi HyperOS and OPPO ColorOS
+**Solution:** TTS not initialized, queuing request
+1. Add the following to AndroidManifest.xml:
+``` xml
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.TTS_SERVICE" />
+        </intent>
+    </queries>
+```
+
 ### iOS: Voices sound robotic
 
 **Solution:** Download enhanced voices:


### PR DESCRIPTION
Problem:Failed to initialized in Xiaomi devices
Devices:Xiaomi Redmi Pad Pro
OS:Xiaomi HyperOS 2.0.207.0 - Android 15
Android debug logs:
``` logs
06-09 22:34:58.871 18776 18776 I Tauri/Console: File: http://tauri.localhost/src/App.vue - Line 117 - Msg: === 开始测试 TTS ===
06-09 22:34:58.871 18776 18776 I Tauri/Console: File: http://tauri.localhost/src/App.vue - Line 119 - Msg: 调用 speak API...
06-09 22:34:58.900 18776 18776 I TtsPlugin: speak() CALLED
06-09 22:34:58.910 18776 18776 W TtsPlugin:   TTS not initialized, queuing request (queue size: 0)
```
Google TTS:
language:Mandarin(China Mainland)
``` shell
> adb shell pm list packages | grep tts                                                           
package:com.google.android.tts
```
TTS Setting: zh-CN

Cargo.toml:
``` toml
[dependencies]
tauri = { version = "2", features = [] }
tauri-plugin-opener = "2"
serde = { version = "1", features = ["derive"] }
serde_json = "1"
tauri-plugin-tts = "0.1.10"
log = "0.4"
tauri-plugin-log = "2"
```
Cause of the issue: Due to regulatory requirements in Chinese Mainland, Android devices in China need to declare TTS services in the AndroidManifest
Reference:https://blog.csdn.net/weixin_43266090/article/details/143889453